### PR TITLE
Use correct base image, which upgrades to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ghcr.io/opensafely/base-docker
+FROM ghcr.io/opensafely-core/base-docker
 
 # stata needs libpng16
-RUN apt-get update && apt-get install -y libpng16-16  python3 expect
+RUN apt-get update && apt-get install -y libpng16-16 libtinfo5 libncurses5 python3 expect
 
 RUN mkdir -p /usr/local/stata
 COPY bin/ /usr/local/stata
@@ -10,6 +10,6 @@ RUN mkdir /workspace
 WORKDIR /workspace
 RUN mkdir -p /root/ado/plus
 COPY libraries/ /root/ado/plus
-COPY entrypoint.py /tmp
+COPY entrypoint.py /root/
 
-ENTRYPOINT ["/usr/bin/python3", "/tmp/entrypoint.py"]
+ENTRYPOINT ["/usr/bin/python3", "/root/entrypoint.py"]


### PR DESCRIPTION
Also do not but the entrypoint in /tmp, as that does funny things with
docker's layering, as /tmp is a tmpfs when run.