### PR TITLE
Support running as non-root user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 stata.lic
 Stata*Linux*.tar.gz
 tests/*.log
+tests/output/*.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,17 +20,20 @@ LABEL org.opencontainers.image.title="stata-mp" \
       org.opencontainers.image.source="https://github.com/opensafely-core/stata-docker" \
       org.opensafely.action="stata-mp"
 
-RUN mkdir -p /usr/local/stata /workspace /root/ado/plus
-
 # stata needs libpng16
 COPY packages.txt /root/packages.txt
 RUN /root/docker-apt-install.sh /root/packages.txt
 
+ENV STATA_SITE=/usr/local/ado
+RUN mkdir -p /usr/local/stata /workspace $STATA_SITE && \
+    chmod 777 $STATA_SITE && \
+    ln -s /tmp/stata.lic /usr/local/stata/stata.lic
 WORKDIR /workspace
+
 COPY bin/ /usr/local/stata
-COPY libraries/ /root/ado/plus
-COPY entrypoint.sh /root/
-ENTRYPOINT ["/root/entrypoint.sh"]
+COPY libraries/* $STATA_SITE/
+COPY entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # tag with build info as the very last step, as it will never be cached
 ARG BUILD_DATE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 test -z "${STATA_LICENSE:-}" && { echo "No STATA_LICENSE environment variable found"; exit 1; }
-echo "$STATA_LICENSE" > /usr/local/stata/stata.lic
+echo "$STATA_LICENSE" >  /tmp/stata.lic
 
 script="$1"
 shift
@@ -12,7 +12,7 @@ test -f "$script" || { echo "$script does not exist"; exit 1; }
 # make any local study libraries automatically available
 if test -d /workspace/libraries; then
     for lib in /workspace/libraries/*.ado; do
-        ln -s "$lib" /root/ado/plus/
+        ln -s "$lib" "$STATA_SITE/"
     done
 fi
 

--- a/tests/analysis/custom.do
+++ b/tests/analysis/custom.do
@@ -1,0 +1,1 @@
+customcmd

--- a/tests/analysis/gz.do
+++ b/tests/analysis/gz.do
@@ -1,0 +1,5 @@
+!gunzip output/input.csv.gz
+// now import the uncompressed csv using delimited
+import delimited using output/input.csv
+// save in compressed dta.gz format
+gzsave output/model.dta.gz

--- a/tests/libraries/customcmd.ado
+++ b/tests/libraries/customcmd.ado
@@ -1,0 +1,3 @@
+program define customcmd
+display "custom command called"
+end


### PR DESCRIPTION
Previously, we relied on various paths inside the image that required
root privileges to read or write. Specifically:

1. We need to write the env var supplied license to
   `/usr/local/stata/stata.lic`. This is handle via symlink
2. We used the /root/entrypoint.sh - this has been move to
   /usr/local/bin/entrypoint.sh
3. We shipped various core libraries in /root/ado/plus, which is one of
   the default per-user locations. Apart from the path permissions, the
   'plus' package namespace is often used by users in their own code[1].
   So instead, switch to /usr/local/ado, the default SITE location,
   which a) is outside /root/ and b) matches our intended usage, and is
   b/w compat with users using their own PLUS or PERSONAL paths in
   analysis code.
4. We autoload ./libraries/*.ado, which is now done as the user running
   the command, so need to also work non-root. For now, to avoid further
   collisions with use of PLUS, we add them to the SITE dir. This did
   require making the SITE dir world writable, so that we can link into
   it.

Given the changes above, added test coverage for both the stata
libraries shipped with the docker image, as well as studies with
./libraries/.
