### PR TITLE
fix: make stata image more interactive

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+bin/stata

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # design.
 #
 # hadolint ignore=DL3006
-FROM ghcr.io/opensafely-core/base-docker
+FROM ghcr.io/opensafely-core/base-action
 
 # Some static metadata for this specific image, as defined by:
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
@@ -19,6 +19,7 @@ LABEL org.opencontainers.image.title="stata-mp" \
       org.opencontainers.image.description="Stata action for opensafely.org" \
       org.opencontainers.image.source="https://github.com/opensafely-core/stata-docker" \
       org.opensafely.action="stata-mp"
+
 
 # stata needs libpng16
 COPY packages.txt /root/packages.txt
@@ -31,9 +32,11 @@ RUN mkdir -p /usr/local/stata /workspace $STATA_SITE && \
 WORKDIR /workspace
 
 COPY bin/ /usr/local/stata
+COPY stata-wrapper.sh /usr/local/bin/stata
+COPY stata-wrapper.sh /usr/local/bin/stata-mp
 COPY libraries/* $STATA_SITE/
-COPY entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+COPY script-wrapper.sh /usr/local/bin/script-wrapper.sh
+ENV ACTION_EXEC="/usr/local/bin/script-wrapper.sh"
 
 # tag with build info as the very last step, as it will never be cached
 ARG BUILD_DATE

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build:
 lint:
 	@docker pull hadolint/hadolint
 	docker run --rm -i hadolint/hadolint < Dockerfile
-	shellcheck entrypoint.sh scripts/*.sh tests/*.sh
+	shellcheck *.sh scripts/*.sh tests/*.sh
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -52,12 +52,11 @@ generate a new license file, first obtain the new details (provided in a PDF fil
 
 Then run:
 
-    docker run --rm -v $PWD:/src -w /usr/local/stata --entrypoint /src/scripts/renew-license.sh ghcr.io/opensafely-core/stata-mp 'SERIAL' 'CODE' 'AUTH'
+    docker run --rm -v --user "$(id -u):$(id -g)" $PWD:/src -w /usr/local/stata --entrypoint /src/scripts/renew-license.sh ghcr.io/opensafely-core/stata-mp 'SERIAL' 'CODE' 'AUTH'
 
 (Note the single quotes to ensure the code/auth are passed literally.)
 
-The resulting file will be copied to `./stata.lic` (note: due to docker
-shenanigans, it will be owned by root). You can test this works with:
+The resulting file will be copied to `./stata.lic` You can test this works with:
 
     ./scripts/test-license.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       # should speed up the build in CI, where we have a cold cache
       cache_from:  # should speed up the build in CI, where we have a cold cache
-        - ghcr.io/opensafely-core/base-docker
+        - ghcr.io/opensafely-core/base-action
         - ghcr.io/opensafely-core/stata-mp
       args:
         # this makes the image work for later cache_from: usage

--- a/script-wrapper.sh
+++ b/script-wrapper.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-test -z "${STATA_LICENSE:-}" && { echo "No STATA_LICENSE environment variable found"; exit 1; }
-echo "$STATA_LICENSE" >  /tmp/stata.lic
-
-script="$1"
+script="${1:-}"
 shift
 
 test -f "$script" || { echo "$script does not exist"; exit 1; }
@@ -40,7 +37,7 @@ EOF
 # clean up wrapper afterwards, or else it leaves files owned by root in /workspace
 trap 'rm -f $wrapper' EXIT
 
-/usr/local/stata/stata "$wrapper" "$@" < /dev/null | tee "$log"
+/usr/local/bin/stata "$wrapper" "$@" < /dev/null | tee "$log"
 
 # exit cleanly if we find the file has been written
 grep -q success "$success" 2>/dev/null

--- a/script-wrapper.sh
+++ b/script-wrapper.sh
@@ -20,7 +20,7 @@ fi
 # running a script, if there is an error, it will stop, and not write the file,
 # so we can use this as a proxy for success or failure.
 success=$(mktemp)
-wrapper=${script%.do}.wrapper.do
+wrapper=$(mktemp).do
 
 # batch mode writes output for script.do to script.log in PWD, so we preserve that
 # behaviour
@@ -33,9 +33,6 @@ cat <<EOF > "$wrapper"
 . file write output "success" 
 . file close output
 EOF
-
-# clean up wrapper afterwards, or else it leaves files owned by root in /workspace
-trap 'rm -f $wrapper' EXIT
 
 /usr/local/bin/stata "$wrapper" "$@" < /dev/null | tee "$log"
 

--- a/stata-wrapper.sh
+++ b/stata-wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+test -z "${STATA_LICENSE:-}" && { echo "No STATA_LICENSE environment variable found"; exit 1; }
+echo "$STATA_LICENSE" >  /tmp/stata.lic
+
+exec /usr/local/stata/stata-mp "$@"


### PR DESCRIPTION
The stata image was not based on base-action, and did not use
ACTION_EXEC to take advantage of the ability to run any executable in
the image.

So, this meant its custom entrypoint wouldn't work well with opensafely
exec if you just wanted to run stata interactively.

And whilst you could use `--entrypoint /usr/bin/stata/stata`, you'd a)
have to know to do that and b) lose the STATA_LICENSE env var set up.

So, this fixes that by:

 - switching to base-action, and using ACTION_EXEC to set the default
   script to use.. This means that `opensafely exec stata-mp stata` or
   `opensafely exec stata-mp bash` will just work as expected.

 - To work around the license issue, we add a simple stata executable
   wrapper that sets the license, and is on the path, and that is our
   stata executable, whether using the script-wrapper.sh or running via
   CMD.

Along the way, I realised I'd accidentally regressed to using the non-mp
version of stata a long time ago. This fixes that, and makes all stata
be stata-mp. We avoid copying the non-mp binary into the image at all.
