### PR TITLE
Fix updated argument name in arrowload help file

### DIFF
--- a/libraries/arrowload.sthlp
+++ b/libraries/arrowload.sthlp
@@ -41,4 +41,4 @@ Examples
 
     . arrowload "/workspace/dataset.arrow"
 
-    . arrowload "/workspace/dataset.arrow", aliases("/workspace/aliases.csv")
+    . arrowload "/workspace/dataset.arrow", configfile("/workspace/config.csv")


### PR DESCRIPTION
The `aliases` argument was renamed to `configfile` to allow for the option of loading other config from a file in the future.