### PR TITLE
Improve user messaging for arrowload command

### DIFF
--- a/libraries/arrowload.ado
+++ b/libraries/arrowload.ado
@@ -5,7 +5,8 @@ prog define arrowload
     syntax anything(name=filename)   ///
     [,                               ///
     Configfile(string)               ///
+    Verbosity(integer 3)               ///
     ]
     if ( mi("`configfile'") ) local configfile none
-    python script /python_scripts/load_arrow.py, args(`filename' `configfile')
+    python script /python_scripts/load_arrow.py, args(`filename' `configfile' `verbosity')
 end

--- a/libraries/arrowload.sthlp
+++ b/libraries/arrowload.sthlp
@@ -9,17 +9,26 @@ Syntax
 
         arrowload filename [, options]
 
-    options               Description
+    options                           Description
     ---------------------------------------------------------------------------------
     Main
       configfile(path/to/csv/file)    A csv file containing configuration for the import
+      verbosity(#)                    An integer to control the level of output;
+                                      default verbosity(3)
     ---------------------------------------------------------------------------------
 
 
 Description
 -----------
 
-    arrowload loads an arrow file
+    arrowload loads an arrow file into the stata dataset.
+
+    Columns in the arrow file are converted to the most appropriate stata variable type.
+
+    NOTE: Integer types will be loaded as byte, int or long, depending on the values of the
+    column in the arrow data. If the arrow data contains integers that are larger than 32 bit,
+    which cannot be represented as an integer in stata, the column will be loaded as a
+    string column, and values will be string representations of the integers.
 
 
 Options
@@ -35,10 +44,15 @@ Options
           long for use in stata. However, it is preferable fix the input file to use valid
           names. Some or all variable names can be mapped.
 
+    verbosity determine the level of output
+        - 1: prints minimal info messages
+        - 2: prints warnings only
+        - 3: prints all info messages (the default)
+
 
 Examples
 --------
-
-    . arrowload "/workspace/dataset.arrow"
-
-    . arrowload "/workspace/dataset.arrow", configfile("/workspace/config.csv")
+    . arrowload /workspace/dataset.arrow
+    . arrowload /workspace/dataset.arrow, verbosity(1)
+    . arrowload /workspace/dataset.arrow, configfile(/workspace/config.csv)
+    . arrowload /workspace/dataset.arrow, configfile(/workspace/config.csv) verbosity(2)

--- a/python_scripts/load_arrow.py
+++ b/python_scripts/load_arrow.py
@@ -202,7 +202,7 @@ class ArrowConverter:
         if batch_type is None:
             # range is too big for stata integer types
             self.display(
-                f"Column {column_name} is out of integer range; converting to string"
+                f"Column '{column_name}' is out of integer range; converting to string"
             )
             batch = self.convert_int64_column_to_string(batch, column_name)
             batch_type = "string"
@@ -288,7 +288,7 @@ class ArrowConverter:
                     self.aliases.get(varname, varname), prefix=False
                 )
                 if cleaned_name != varname:
-                    self.display(f"{varname} aliased to {cleaned_name}")
+                    self.display(f"'{varname}' aliased to '{cleaned_name}'")
                 self.column_names.append(cleaned_name)
 
             if too_long_names:
@@ -450,7 +450,7 @@ class ArrowConverter:
                     sfi.Data.addVarFloat(varname)
                 else:
                     print_error_and_exit(
-                        f"Unhandled type: {vartype} for column {varname}"
+                        f"Unhandled type: {vartype} for column '{varname}'"
                     )
         else:
             # If any columns have changed required type when we process a

--- a/python_scripts/load_arrow.py
+++ b/python_scripts/load_arrow.py
@@ -19,6 +19,9 @@ from pyarrow.types import (
 def main(filename, configfile=None):
     if not Path(filename).exists():
         print_error_and_exit(f"Arrow file not found at {filename}", 601)
+    if sfi.Data.getVarCount() > 0:
+        # exit with the standard "dataset in memory has changed" message
+        print_error_and_exit(None, 4)
     converter = ArrowConverter(filename, configfile)
     converter.load_data()
 
@@ -33,7 +36,8 @@ def print_error_and_exit(message, error_code=7103):
     Otherwise, default to 7103, which is a generic stata return code
     when it can't execute a python script
     """
-    sfi.SFIToolkit.errprintln(message)
+    if message:
+        sfi.SFIToolkit.errprintln(message)
     sfi.SFIToolkit.error(error_code)
 
 

--- a/tests/analysis/arrowload/arrowload-verbosity-default.do
+++ b/tests/analysis/arrowload/arrowload-verbosity-default.do
@@ -1,0 +1,1 @@
+. arrowload fixtures/data.arrow, configfile(non_existent_file) verbosity(4)

--- a/tests/analysis/arrowload/arrowload-verbosity-none.do
+++ b/tests/analysis/arrowload/arrowload-verbosity-none.do
@@ -1,0 +1,1 @@
+. arrowload fixtures/data.arrow, configfile(non_existent_file) verbosity(1)

--- a/tests/analysis/arrowload/arrowload-verbosity-warning.do
+++ b/tests/analysis/arrowload/arrowload-verbosity-warning.do
@@ -1,0 +1,1 @@
+. arrowload fixtures/data.arrow, configfile(non_existent_file) verbosity(2)

--- a/tests/analysis/arrowload/arrowload-with-existing-data.do
+++ b/tests/analysis/arrowload/arrowload-with-existing-data.do
@@ -1,0 +1,2 @@
+. generate foo=1
+. arrowload fixtures/data.arrow

--- a/tests/test_arrowload.py
+++ b/tests/test_arrowload.py
@@ -315,8 +315,8 @@ def test_arrowload_aliases_with_multiple_batches():
     return_code, output, _ = run_stata(
         "analysis/arrowload/arrowload-batches-aliased.do"
     )
-    assert "i3a aliased to aliased_i3a" in output
-    assert "s1 aliased to aliased_s1" in output
+    assert "'i3a' aliased to 'aliased_i3a'" in output
+    assert "'s1' aliased to 'aliased_s1'" in output
     assert return_code == 0
 
 

--- a/tests/test_arrowload.py
+++ b/tests/test_arrowload.py
@@ -330,3 +330,40 @@ def test_arrowload_data_exists():
     )
     assert return_code == 1
     assert "no; dataset in memory has changed since last saved" in output
+
+
+def test_arrowload_verbosity():
+    # All .do files in this test attempt to load valid data with a
+    # non-existent configfile, which outputs a warning, if verbosity
+    # level allows
+
+    # the progress message is always shown
+    progress_message = "Reading batch 1 of 1"
+    # warnings are shown with verbosity level 2 or 3
+    warning_message = "WARNING: Config file not found"
+    # other output messages are only shown with verbosity level 3
+    info_message = "Finalising column"
+
+    # Verbosity level 2
+    return_code, output, _ = run_stata(
+        "analysis/arrowload/arrowload-verbosity-warning.do"
+    )
+    assert return_code == 0
+    for message in [progress_message, warning_message]:
+        assert message in output
+    assert info_message not in output
+
+    # Verbosity level 1
+    return_code, output, _ = run_stata("analysis/arrowload/arrowload-verbosity-none.do")
+    assert return_code == 0
+    assert progress_message in output
+    for message in [warning_message, info_message]:
+        assert message not in output
+
+    # Verbosity level 4 (invalid, defaults to 3)
+    return_code, output, _ = run_stata(
+        "analysis/arrowload/arrowload-verbosity-default.do"
+    )
+    assert return_code == 0
+    for message in [progress_message, warning_message, info_message]:
+        assert message in output

--- a/tests/test_arrowload.py
+++ b/tests/test_arrowload.py
@@ -318,3 +318,15 @@ def test_arrowload_aliases_with_multiple_batches():
     assert "i3a aliased to aliased_i3a" in output
     assert "s1 aliased to aliased_s1" in output
     assert return_code == 0
+
+
+def test_arrowload_data_exists():
+    """
+    Test that loading an arrow file when data already exists returns
+    the expected error message
+    """
+    return_code, output, _ = run_stata(
+        "analysis/arrowload/arrowload-with-existing-data.do"
+    )
+    assert return_code == 1
+    assert "no; dataset in memory has changed since last saved" in output

--- a/tests/test_arrowload.py
+++ b/tests/test_arrowload.py
@@ -342,7 +342,7 @@ def test_arrowload_verbosity():
     # warnings are shown with verbosity level 2 or 3
     warning_message = "WARNING: Config file not found"
     # other output messages are only shown with verbosity level 3
-    info_message = "Finalising column"
+    info_message = "Finalising missing values"
 
     # Verbosity level 2
     return_code, output, _ = run_stata(

--- a/tests/test_arrowload.py
+++ b/tests/test_arrowload.py
@@ -243,7 +243,7 @@ def test_arrowload_multiple_batch():
 
 def test_arrowload_too_long_variable_names():
     """
-    Variable names that are too long for stata variables raise an error
+    Variable names that are too long for stata variables print an error message and exit
     """
     return_code, output, _ = run_stata("analysis/arrowload/arrowload-too-long.do")
     assert return_code == 1
@@ -261,11 +261,12 @@ def test_arrowload_aliased_long_variable_names():
 
 def test_arrowload_bad_aliases():
     """
-    Aliased variable names that are too long for stata variables raise an error
+    Aliased variable names that are too long for stata variables print an error
+    message and exit
     """
     return_code, output, _ = run_stata("analysis/arrowload/arrowload-bad-aliases.do")
     assert return_code == 1
-    assert "aliases longer than the allowed length" in output
+    assert "Config file contains aliases longer than the allowed length" in output
 
 
 def test_arrowload_config_file_not_found():


### PR DESCRIPTION
Makes things nicer for users by:

1) Using the sfi module to display messages instead of print statements
2) Outputting stata error messages and exiting with stata exit codes instead of raising python exceptions. This means that for caught exceptions, the user sees a familiar looking stata message and exit code, rather than an unexpected python traceback.
3) Checking and exiting with stata's usual "dataset has changed" error message if we try to read an arrow file and there is data already in the stata dataset (this happens if you try to load an arrow file without clearing the stata dataset first); this should be expected behaviour for stata users. The `import delimited` command for importing csv files works the same way,
4) Adds a `verbosity` arg so users can choose to suppress the output of the arrowload command
