### PR TITLE
Run tests on pushes to main

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,8 @@
 name: Tests
 on:
   pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
 env:
   IMAGE_NAME: stata-mp


### PR DESCRIPTION
The build and publish step is skipped if the tests workflow didn't succeed, and we're not currently running the tests on pushes to main, so it's always skipped