### PR TITLE
Update ppa domain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM ghcr.io/opensafely-core/base-action:22.04 as base
 # use space efficient utility from base image
 
 RUN --mount=type=cache,target=/var/cache/apt \
-    echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
+    echo "deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
     /usr/lib/apt/apt-helper download-file 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776' /etc/apt/trusted.gpg.d/deadsnakes.asc
 
 # stata needs libpng16, install python dependencies


### PR DESCRIPTION
ppa domains changed in 2022; although the old ones were supposed to remain indefinitely, they're currently inaccessible; but we should update to the new one anyway

https://blog.launchpad.net/ppa/new-domain-names-for-ppas