### PR TITLE
Make `opensafely exec stata-mp` just work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ COPY libraries/* $STATA_SITE/
 COPY python_scripts/ /python_scripts
 COPY script-wrapper.sh /usr/local/bin/script-wrapper.sh
 ENV ACTION_EXEC="/usr/local/bin/script-wrapper.sh"
+ENV INTERACTIVE_EXEC="/usr/local/bin/stata"
 
 # tag with build info as the very last step, as it will never be cached
 ARG BUILD_DATE

--- a/justfile
+++ b/justfile
@@ -123,7 +123,7 @@ fix: devenv
     $BIN/ruff --fix .
 
 build: _env
-    docker-compose build --pull stata-mp
+    docker compose build --pull stata-mp
 
 test *args: devenv
     $BIN/pytest {{ args }}

--- a/stata-wrapper.sh
+++ b/stata-wrapper.sh
@@ -7,7 +7,7 @@ echo "$STATA_LICENSE" >  /tmp/stata.lic
 # make any local study libraries automatically available
 if test -d /workspace/libraries; then
     for lib in /workspace/libraries/*.ado; do
-        ln -s "$lib" "$STATA_SITE/"
+        ln -sf "$lib" "$STATA_SITE/"
     done
 fi
 


### PR DESCRIPTION
- **pull base image on builds**
- **Fix bug in ./libraries usage**
- **Make `opensafely exec stata-mp` just work**
