### PR TITLE
Add convert utility for output images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,12 @@ RUN --mount=type=cache,target=/var/cache/apt \
     echo "deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
     /usr/lib/apt/apt-helper download-file 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776' /etc/apt/trusted.gpg.d/deadsnakes.asc
 
-# stata needs libpng16, install python dependencies
+# stata needs libpng16, install python dependencies, and imagemagick
+# edit imagemagick policy to allow eps conversion, which is disabled by default
 COPY packages.txt /root/packages.txt
 RUN --mount=type=cache,target=/var/cache/apt \
-    /root/docker-apt-install.sh /root/packages.txt
+    /root/docker-apt-install.sh /root/packages.txt &&\
+    sed -i -z 's#<!-- disable ghostscript.*</policymap>#</policymap>#g' /etc/ImageMagick-6/policy.xml
 
 # set PYTHONUSERBASE for installing user packages
 ENV PYTHONUSERBASE=/usr/local

--- a/packages.txt
+++ b/packages.txt
@@ -1,6 +1,6 @@
 # needed by stata
-libpng16-16 
-libtinfo5 
+libpng16-16
+libtinfo5
 libncurses5
 # python
 libpython3.11
@@ -8,3 +8,6 @@ python3.11
 python3.11-distutils
 python3-pip
 python3.11-venv
+# to generate more formats, as stata on linux can only do eps/svg/tiff
+ghostscript
+imagemagick

--- a/tests/analysis/convert.do
+++ b/tests/analysis/convert.do
@@ -1,0 +1,13 @@
+* Create a simple dataset
+set obs 10  // Create 10 observations
+gen x = _n  // Create variable x as the observation number
+gen y = x^2 // Create variable y as x squared
+
+* Generate a scatterplot of y vs. x
+graph twoway scatter y x, title("Test Graph") xlabel(, grid) ylabel(, grid)
+
+* Save the graph as a file
+graph export "test.eps", replace
+
+* convert to png using convert utility
+! convert test.eps test.png

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -21,7 +21,10 @@ def sanitize(string):
     return RE_WHITESPACE.sub(" ", string).strip()
 
 
-def run_stata(command):
+def run_stata(command, workspace=None):
+    if workspace is None:
+        workspace = TESTS_PATH.resolve()
+
     command_list = command.split()
     filestem = Path(command_list[0]).stem
     uid = os.getuid()
@@ -36,13 +39,13 @@ def run_stata(command):
             "-e",
             "STATA_LICENSE",
             "-v",
-            f"{TESTS_PATH.resolve()}:/workspace",
+            f"{workspace}:/workspace",
             IMAGE,
             *command_list,
         ],
         capture_output=True,
     )
-    log_file = TESTS_PATH / f"{filestem}.log"
+    log_file = workspace / f"{filestem}.log"
     # The log file should always exist, even if the .do file failed to load.
     # If it doesn't, something probably went wrong with running the container itself,
     # so fail and report the process stderr.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,5 @@
+import shutil
+
 from .helpers import run_stata
 
 
@@ -15,3 +17,11 @@ def test_basic_stata_fails():
     assert return_code == 1
     for content in [output, log_content]:
         assert "badstring" in content
+
+
+def test_convert_image(tmp_path):
+    shutil.copy("tests/analysis/convert.do", tmp_path)
+
+    return_code, output, log_content = run_stata("convert.do", workspace=tmp_path)
+    assert return_code == 0
+    assert (tmp_path / "test.png").exists()


### PR DESCRIPTION
stata on linux console can only output eps, svg, and tiff files. Adding
the convert cli tool allows a user to generate pngs and other formats.

There's some weirdness that eps is disabled by default for obsolete
security reasons, so we need to enable it.
