### PR TITLE
Tag release as v1

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -35,5 +35,8 @@ jobs:
       - name: Push image to GitHub Container Registry
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          docker tag $IMAGE_NAME $IMAGE_ID:v1
+          docker push $IMAGE_ID:v1
+          # v1 is also latest currently
           docker tag $IMAGE_NAME $IMAGE_ID:latest
           docker push $IMAGE_ID:latest


### PR DESCRIPTION
This means all our images support the :v1 tag, and we can start deprecating :latest