### PR TITLE
Restrict GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -13,7 +13,9 @@ on:
 env:
   IMAGE_NAME: stata-mp
   STATA_LICENSE: ${{ secrets.STATA_LICENSE }}
-
+permissions:
+  contents: read
+  packages: write
 
 jobs:
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,8 @@ on:
 env:
   IMAGE_NAME: stata-mp
   STATA_LICENSE: ${{ secrets.STATA_LICENSE }}
+permissions:
+  contents: read
 
 jobs:
 


### PR DESCRIPTION
Ensure workflows have the minimum required permissions and silence the security alerts